### PR TITLE
feat: add login and register events

### DIFF
--- a/js/src/common/DefaultEvents/UserLoggedIn.ts
+++ b/js/src/common/DefaultEvents/UserLoggedIn.ts
@@ -1,0 +1,16 @@
+import { FathomEvent } from '../EventsRepository';
+import { extend } from 'flarum/common/extend';
+import Session from 'flarum/common/Session';
+
+export default {
+  name: 'User logged in',
+  description: 'Triggered when a user logs in',
+  id: 'user-log-in',
+  code(e: FathomEvent) {
+    extend(Session.prototype, 'login', function (promise) {
+      promise.then(() => {
+        e.track();
+      });
+    });
+  },
+} as FathomEvent;

--- a/js/src/common/DefaultEvents/UserRegister.ts
+++ b/js/src/common/DefaultEvents/UserRegister.ts
@@ -1,0 +1,31 @@
+import { FathomEvent } from '../EventsRepository';
+import { override } from 'flarum/common/extend';
+import SignUpModal from 'flarum/forum/components/SignUpModal';
+import app from 'flarum/forum/app';
+
+export default {
+  name: 'User registers',
+  description: 'Triggered when a user registers on the forum',
+  id: 'user-register',
+  code(fathomEv: FathomEvent) {
+    override(SignUpModal.prototype, 'onsubmit', function (this: SignUpModal, orig, domEv) {
+      domEv.preventDefault();
+
+      this.loading = true;
+
+      const body = this.submitData();
+
+      app
+        .request({
+          url: app.forum.attribute('baseUrl') + '/register',
+          method: 'POST',
+          body,
+          errorHandler: this.onerror.bind(this),
+        })
+        .then(() => {
+          fathomEv.track();
+          window.location.reload();
+        }, this.loaded.bind(this));
+    });
+  },
+} as FathomEvent;

--- a/js/src/common/DefaultEvents/index.ts
+++ b/js/src/common/DefaultEvents/index.ts
@@ -2,3 +2,5 @@ export { default as OpenLogInModal } from './OpenLogInModal';
 export { default as OpenSignUpModal } from './OpenSignUpModal';
 export { default as ViewBlogIndexPage } from './ViewBlogIndexPage';
 export { default as ViewTagsPage } from './ViewTagsPage';
+export { default as UserLoggedIn } from './UserLoggedIn';
+export { default as UserRegister } from './UserRegister';


### PR DESCRIPTION
Tracking won't be perfect on these, but it's as close as we can really get when only using the frontend.

Login tracks on a successful sign in from `app.session.login`, while sign up waits for a successful submission of the SignUpModal but this means other auth sources, if any, will not be counted.